### PR TITLE
jwtのguardとuser decoratorとリクエスト送信修正

### DIFF
--- a/backend/src/context/Auth/decorator/jwtAuth.decorator.ts
+++ b/backend/src/context/Auth/decorator/jwtAuth.decorator.ts
@@ -1,0 +1,6 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { jwtAuthGuard } from '../guard/jwtAuth.guard';
+
+export function JwtAuth() {
+  return applyDecorators(UseGuards(jwtAuthGuard));
+}

--- a/backend/src/context/Auth/decorator/jwtAuth.decorator.ts
+++ b/backend/src/context/Auth/decorator/jwtAuth.decorator.ts
@@ -1,6 +1,6 @@
 import { applyDecorators, UseGuards } from '@nestjs/common';
-import { jwtAuthGuard } from '../guard/jwtAuth.guard';
+import { JwtAuthGuard } from '../guard/jwtAuth.guard';
 
 export function JwtAuth() {
-  return applyDecorators(UseGuards(jwtAuthGuard));
+  return applyDecorators(UseGuards(JwtAuthGuard));
 }

--- a/backend/src/context/Auth/guard/jwtAuth.guard.ts
+++ b/backend/src/context/Auth/guard/jwtAuth.guard.ts
@@ -1,0 +1,37 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { JwtAuthUsecase } from '../usecase/jwtAuth.usecase';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+@Injectable()
+export class jwtAuthGuard implements CanActivate {
+  constructor(private readonly jwtAuthService: JwtAuthUsecase) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const ctx = GqlExecutionContext.create(context);
+    const request = ctx.getContext().req;
+    const token = this.extractTokenFromHeader(request);
+
+    if (!token) {
+      throw new UnauthorizedException();
+    }
+
+    try {
+      const payload = await this.jwtAuthService.verifyToken(token);
+      request['user'] = payload;
+    } catch {
+      throw new UnauthorizedException();
+    }
+    return true;
+  }
+
+  private extractTokenFromHeader(request: Request): string | undefined {
+    const [type, token] = request.headers.authorization?.split(' ') ?? [];
+    return type === 'Bearer' ? token : undefined;
+  }
+}

--- a/backend/src/context/Auth/guard/jwtAuth.guard.ts
+++ b/backend/src/context/Auth/guard/jwtAuth.guard.ts
@@ -9,7 +9,7 @@ import { JwtAuthUsecase } from '../usecase/jwtAuth.usecase';
 import { GqlExecutionContext } from '@nestjs/graphql';
 
 @Injectable()
-export class jwtAuthGuard implements CanActivate {
+export class JwtAuthGuard implements CanActivate {
   constructor(private readonly jwtAuthService: JwtAuthUsecase) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {

--- a/backend/src/context/Auth/test/guard/jwtAuth.guard.test.ts
+++ b/backend/src/context/Auth/test/guard/jwtAuth.guard.test.ts
@@ -1,0 +1,91 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ExecutionContext } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtAuthGuard } from '../../guard/jwtAuth.guard';
+import { JwtAuthUsecase } from '../../usecase/jwtAuth.usecase';
+
+describe('JwtAuthGuard', () => {
+  let guard: JwtAuthGuard;
+  let usecase: JwtAuthUsecase;
+
+  const mockExecutionContext: Partial<ExecutionContext> = {
+    switchToHttp: jest.fn(),
+  };
+
+  const mockGqlExecutionContext = {
+    create: jest.fn().mockReturnValue({
+      getContext: jest.fn().mockReturnValue({
+        req: {
+          headers: {
+            authorization: 'Bearer valid-token',
+          },
+        },
+      }),
+    }),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JwtAuthGuard,
+        {
+          provide: JwtAuthUsecase,
+          useValue: {
+            verifyToken: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    guard = module.get<JwtAuthGuard>(JwtAuthGuard);
+    usecase = module.get<JwtAuthUsecase>(JwtAuthUsecase);
+  });
+
+  it('tokenが正しいとき、trueが返る', async () => {
+    jest
+      .spyOn(GqlExecutionContext, 'create')
+      .mockReturnValue(mockGqlExecutionContext.create());
+    usecase.verifyToken = jest.fn().mockResolvedValue({ userId: 1 });
+
+    const result = await guard.canActivate(
+      mockExecutionContext as ExecutionContext,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('tokenが不明な時、エラーになる', async () => {
+    const mockGqlExecutionContext = {
+      create: jest.fn().mockReturnValue({
+        getContext: jest.fn().mockReturnValue({
+          req: {
+            headers: {
+              authorization: '',
+            },
+          },
+        }),
+      }),
+    };
+
+    jest
+      .spyOn(GqlExecutionContext, 'create')
+      .mockReturnValue(mockGqlExecutionContext.create());
+
+    await expect(guard.canActivate({} as ExecutionContext)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('tokenが無効な時、エラーになる', async () => {
+    jest
+      .spyOn(GqlExecutionContext, 'create')
+      .mockReturnValue(mockGqlExecutionContext.create());
+    usecase.verifyToken = jest
+      .fn()
+      .mockRejectedValue(new Error('Invalid token'));
+
+    await expect(
+      guard.canActivate(mockExecutionContext as ExecutionContext),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+});

--- a/backend/src/context/Auth/usecase/jwtAuth.usecase.ts
+++ b/backend/src/context/Auth/usecase/jwtAuth.usecase.ts
@@ -10,6 +10,13 @@ export class JwtAuthUsecase {
   constructor(private readonly jwtService: JwtService) {}
 
   async generateToken(input: AuthType): Promise<string> {
+    console.log('=====================================');
+    console.log(this.jwtService.sign({ userId: input.id }));
+    console.log('=====================================');
     return this.jwtService.sign({ userId: input.id });
+  }
+
+  async verifyToken(token: string) {
+    return this.jwtService.verifyAsync(token);
   }
 }

--- a/backend/src/context/Auth/usecase/jwtAuth.usecase.ts
+++ b/backend/src/context/Auth/usecase/jwtAuth.usecase.ts
@@ -10,9 +10,6 @@ export class JwtAuthUsecase {
   constructor(private readonly jwtService: JwtService) {}
 
   async generateToken(input: AuthType): Promise<string> {
-    console.log('=====================================');
-    console.log(this.jwtService.sign({ userId: input.id }));
-    console.log('=====================================');
     return this.jwtService.sign({ userId: input.id });
   }
 

--- a/backend/src/context/User/adapters/resolver/request.resolver.ts
+++ b/backend/src/context/User/adapters/resolver/request.resolver.ts
@@ -14,7 +14,7 @@ export class RequestResolver {
     @User() user,
     @Args('mailaddress') mailaddress: string,
   ): Promise<Boolean> {
-    const senderMailaddress = user.mailaddress;
-    return this.sendRequestUsecase.execute(senderMailaddress, mailaddress);
+    const userId = user.userId;
+    return this.sendRequestUsecase.execute(userId, mailaddress);
   }
 }

--- a/backend/src/context/User/adapters/resolver/request.resolver.ts
+++ b/backend/src/context/User/adapters/resolver/request.resolver.ts
@@ -1,16 +1,20 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { SendRequestUsecase } from '../../usecase/sendRequest.usecase';
+import { UseGuards } from '@nestjs/common';
+import { jwtAuthGuard } from 'src/context/Auth/guard/jwtAuth.guard';
+import { User } from '../../decorator/user.decorator';
 
 @Resolver()
+@UseGuards(jwtAuthGuard)
 export class RequestResolver {
   constructor(private readonly sendRequestUsecase: SendRequestUsecase) {}
 
   @Mutation(() => Boolean)
   async sendRequest(
+    @User() user,
     @Args('mailaddress') mailaddress: string,
   ): Promise<Boolean> {
-    // TODO: 仮の送信者メールアドレス(seederにあるやつを設定)
-    const senderMailaddress = 'email1@gmail.com';
+    const senderMailaddress = user.mailaddress;
     return this.sendRequestUsecase.execute(senderMailaddress, mailaddress);
   }
 }

--- a/backend/src/context/User/adapters/resolver/request.resolver.ts
+++ b/backend/src/context/User/adapters/resolver/request.resolver.ts
@@ -1,11 +1,10 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { SendRequestUsecase } from '../../usecase/sendRequest.usecase';
-import { UseGuards } from '@nestjs/common';
-import { jwtAuthGuard } from 'src/context/Auth/guard/jwtAuth.guard';
 import { User } from '../../decorator/user.decorator';
+import { JwtAuth } from 'src/context/Auth/decorator/jwtAuth.decorator';
 
 @Resolver()
-@UseGuards(jwtAuthGuard)
+@JwtAuth()
 export class RequestResolver {
   constructor(private readonly sendRequestUsecase: SendRequestUsecase) {}
 

--- a/backend/src/context/User/decorator/user.decorator.ts
+++ b/backend/src/context/User/decorator/user.decorator.ts
@@ -1,0 +1,10 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+export const User = createParamDecorator(
+  (data: unknown, context: ExecutionContext) => {
+    const ctx = GqlExecutionContext.create(context);
+    const request = ctx.getContext().req;
+    return request.user;
+  },
+);

--- a/backend/src/context/User/domain/interface/request.repository.interface.ts
+++ b/backend/src/context/User/domain/interface/request.repository.interface.ts
@@ -1,5 +1,5 @@
 import { RequestModel } from '../model/request.model';
 
 export interface RequestRepositoryInterface {
-  create(from: string, to: string): Promise<RequestModel>;
+  create(fromUserId: string, toUserId: string): Promise<RequestModel>;
 }

--- a/backend/src/context/User/domain/interface/user.repository.interface.ts
+++ b/backend/src/context/User/domain/interface/user.repository.interface.ts
@@ -3,4 +3,5 @@ import { UserModel } from '../model/user.model';
 export interface UserRepositoryInterface {
   getUserByMailaddress(mailaddress: string): Promise<UserModel>;
   create(name: string, mailaddress: string): Promise<UserModel>;
+  findByUserId(id: string): Promise<UserModel>;
 }

--- a/backend/src/context/User/domain/model/valueObject/requestTypeId.value.ts
+++ b/backend/src/context/User/domain/model/valueObject/requestTypeId.value.ts
@@ -4,7 +4,7 @@ export const RequestTypes = {
   REJECTED: 3,
 } as const;
 
-type RequestTypes = (typeof RequestTypes)[keyof typeof RequestTypes];
+export type RequestTypes = (typeof RequestTypes)[keyof typeof RequestTypes];
 
 const isRequestType = (typeId: number): boolean =>
   (Object.values(RequestTypes) as number[]).includes(typeId);

--- a/backend/src/context/User/infra/user.repository.ts
+++ b/backend/src/context/User/infra/user.repository.ts
@@ -25,4 +25,12 @@ export class UserRepository implements UserRepositoryInterface {
 
     return UserModel.create(user);
   }
+
+  async findByUserId(id: string): Promise<UserModel> {
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+    });
+
+    return UserModel.create(user);
+  }
 }

--- a/backend/src/context/User/module/request.module.ts
+++ b/backend/src/context/User/module/request.module.ts
@@ -10,6 +10,9 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { UserRepository } from '../infra/user.repository';
 import { CoupleRepository } from '../infra/couple.repository';
 import { RequestResolver } from '../adapters/resolver/request.resolver';
+import { AuthModule } from 'src/context/Auth/auth.module';
+
+const externalContext = [AuthModule];
 
 const exportProviders = [
   {
@@ -27,6 +30,7 @@ const exportProviders = [
 ];
 
 @Module({
+  imports: [...externalContext],
   providers: [
     RequestResolver,
     SendRequestUsecase,

--- a/backend/src/context/User/test/unit/usecase/login.usecase.test.ts
+++ b/backend/src/context/User/test/unit/usecase/login.usecase.test.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthModule } from 'src/context/Auth/auth.module';
 import { GoogleAuthUsecase } from 'src/context/Auth/usecase/googleAuth.usecase';
 import { JwtAuthUsecase } from 'src/context/Auth/usecase/jwtAuth.usecase';
 import { USER_REPOSITORY } from 'src/context/User/const/user.token';
@@ -21,7 +20,6 @@ const googleAuthUsecaseMock = {
 
 beforeAll(async () => {
   const module: TestingModule = await Test.createTestingModule({
-    imports: [AuthModule],
     providers: [
       LoginUsecase,
       {

--- a/backend/src/context/User/test/unit/usecase/sendRequest.usecase.test.ts
+++ b/backend/src/context/User/test/unit/usecase/sendRequest.usecase.test.ts
@@ -29,6 +29,7 @@ beforeEach(async () => {
         provide: USER_REPOSITORY,
         useValue: {
           getUserByMailaddress: jest.fn(),
+          findByUserId: jest.fn(),
         },
       },
       {
@@ -57,7 +58,12 @@ describe('SendRequestUsecase', () => {
   describe('正常系', () => {
     it('coupleが成立済みの時、falseが返る', async () => {
       const name = 'テスト';
-      const user = UserModel.create({
+      const sender = UserModel.create({
+        id: '8d946a74-f3e1-464c-8cf5-f180e729892a1',
+        name,
+        mailaddress: sendUserMailaddress,
+      });
+      const receiver = UserModel.create({
         id: '8d946a74-f3e1-464c-8cf5-f180e729892a',
         name,
         mailaddress: sendUserMailaddress,
@@ -69,8 +75,9 @@ describe('SendRequestUsecase', () => {
       });
 
       (userRepository.getUserByMailaddress as jest.Mock).mockResolvedValue(
-        user,
+        sender,
       );
+      (userRepository.findByUserId as jest.Mock).mockResolvedValue(receiver);
       (coupleRepository.findByUserId as jest.Mock).mockResolvedValue([couple]);
 
       const result = await usecase.execute(
@@ -85,8 +92,13 @@ describe('SendRequestUsecase', () => {
     });
     it('coupleが未成立の時、trueが返る', async () => {
       const name = 'テスト';
-      const user = UserModel.create({
-        id: '8d946a74-f3e1-464c-8cf5-f180e729892a',
+      const sender = UserModel.create({
+        id: '8d946a74-f3e1-464c-8cf5-f180e729892a1',
+        name,
+        mailaddress: sendUserMailaddress,
+      });
+      const receiver = UserModel.create({
+        id: '8d946a74-f3e1-464c-8cf5-f180e729892a1',
         name,
         mailaddress: sendUserMailaddress,
       });
@@ -98,8 +110,9 @@ describe('SendRequestUsecase', () => {
       });
 
       (userRepository.getUserByMailaddress as jest.Mock).mockResolvedValue(
-        user,
+        sender,
       );
+      (userRepository.findByUserId as jest.Mock).mockResolvedValue(receiver);
       (coupleRepository.findByUserId as jest.Mock).mockResolvedValue([]);
       (requestRepository.create as jest.Mock).mockResolvedValue(request);
 
@@ -126,6 +139,7 @@ describe('SendRequestUsecase', () => {
       ).rejects.toThrow();
 
       expect(userRepository.getUserByMailaddress).toHaveBeenCalled();
+      expect(userRepository.findByUserId).toHaveBeenCalled();
       expect(coupleRepository.findByUserId).not.toHaveBeenCalled();
       expect(requestRepository.create).not.toHaveBeenCalled();
     });

--- a/backend/src/context/User/usecase/sendRequest.usecase.ts
+++ b/backend/src/context/User/usecase/sendRequest.usecase.ts
@@ -19,14 +19,13 @@ export class SendRequestUsecase {
     private readonly requestRepository: RequestRepositoryInterface,
   ) {}
 
-  // TODO: senderMailaddressはjwtとかからとる想定
   async execute(
-    senderMailaddress: string,
+    senderId: string,
     receiverMailaddress: string,
   ): Promise<boolean> {
     try {
       const [sendUser, receivedUser] = await Promise.all([
-        this.userRepository.getUserByMailaddress(senderMailaddress),
+        this.userRepository.findByUserId(senderId),
         this.userRepository.getUserByMailaddress(receiverMailaddress),
       ]);
 


### PR DESCRIPTION
close #37 

## 実装内容
- jwt(認証)のguardをカスタムデコレータで実装
  - テスト追加
- user decoratorを実装
- jwtのカスタムデコレータをリクエスト送信に追記
  - リクエスト送信全体を修正