### PR TITLE
リクエストの承認/拒否機能を実装

### DIFF
--- a/frontend/app/(auth)/home/RecievedRequest.tsx
+++ b/frontend/app/(auth)/home/RecievedRequest.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { accept, reject } from './action';
+import { useState } from 'react';
+
+export const RecievedRequest = ({ fromUserId }: { fromUserId: string }) => {
+  const [isAccepted, setIsAccepted] = useState(false);
+  const [isRejected, setIsRejected] = useState(false);
+  return (
+    <CardContent>
+      <div>リクエストを受け取っています</div>
+      <div>fromUserId: {fromUserId}</div>
+      {isAccepted || isRejected ? (
+        <div>リクエストを{isAccepted ? '承認' : '拒否'}しました</div>
+      ) : (
+        <>
+          <Button
+            onClick={() => {
+              setIsAccepted(true);
+              accept();
+            }}
+          >
+            Accept
+          </Button>
+          <Button
+            onClick={() => {
+              setIsRejected(true);
+              reject();
+            }}
+          >
+            Reject
+          </Button>
+        </>
+      )}
+    </CardContent>
+  );
+};

--- a/frontend/app/(auth)/home/SendRequest.tsx
+++ b/frontend/app/(auth)/home/SendRequest.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { CardHeader, CardContent } from '@/components/ui/card';
+import { useFormState } from 'react-dom';
+import { findUser, sendRequest } from './action';
+import { Input } from '@/components/ui/input';
+
+export const SendRequest = () => {
+  const [state, dispatch] = useFormState(findUser, {
+    mailaddress: '',
+    name: '',
+    error: '',
+  });
+
+  return (
+    <>
+      <CardHeader className="items-center">リクエスト</CardHeader>
+      <CardContent className="grid gap-8">
+        <form action={dispatch}>
+          <label htmlFor="mailaddress">リクエストするメールアドレス</label>
+          <Input id="mailaddress" type="email" name="mailaddress" />
+          {state.error && <div>{state.error}</div>}
+          <Button type="submit">検索</Button>
+        </form>
+
+        {state.mailaddress && (
+          <Request mailaddress={state.mailaddress} name={state.name} />
+        )}
+      </CardContent>
+    </>
+  );
+};
+
+const Request = ({
+  mailaddress,
+  name,
+}: {
+  mailaddress: string;
+  name: string;
+}) => {
+  const [state, dispatch] = useFormState(sendRequest, {
+    mailaddress: '',
+    error: '',
+  });
+
+  return (
+    <form action={dispatch}>
+      <div>
+        <Input
+          type="email"
+          name="mailaddress"
+          defaultValue={mailaddress}
+          readOnly
+        />
+      </div>
+      <div className="text-lg">名前: {name}</div>
+      <Button type="submit">リクエストを送る</Button>
+      {state.error && <div>{state.error}</div>}
+      {!state.error && state.mailaddress && <div>リクエストしました</div>}
+    </form>
+  );
+};

--- a/frontend/app/(auth)/home/page.tsx
+++ b/frontend/app/(auth)/home/page.tsx
@@ -1,66 +1,44 @@
-'use client';
-
-import { findUser, sendRequest } from './action';
 import { Center } from '@/components/layout/center';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { useFormState } from 'react-dom';
+import { Card } from '@/components/ui/card';
+import { SendRequest } from './SendRequest';
+import { gql } from 'graphql-request';
+import { catchTag, gen, runPromise, succeed, tryPromise } from 'effect/Effect';
+import { authClient } from '@/lib/authClient';
+import { GetRequestQuery } from '@/types/gql/graphql';
+import { tag } from '@/lib/Effect.lib';
+import { RecievedRequest } from './RecievedRequest';
 
-export default function Home() {
-  const [state, dispatch] = useFormState(findUser, {
-    mailaddress: '',
-    name: '',
-    error: '',
-  });
+export default async function Home() {
+  const {
+    getRequest: { fromUserId },
+  } = await gen(function* () {
+    const client = yield* authClient();
+    return yield* tryPromise({
+      try: () => client.request<GetRequestQuery>(getRequestQuery),
+      catch: () => tag('no request'),
+    });
+  })
+    .pipe(
+      catchTag('no request', () =>
+        succeed({ getRequest: { fromUserId: null } }),
+      ),
+    )
+    .pipe(runPromise);
 
   return (
     <Center className="m-10">
       <Card className="w-[350px] h-[400px] flex-col items-center justify-center p-5">
-        <CardHeader className="items-center">リクエスト</CardHeader>
-        <CardContent className="grid gap-8">
-          <form action={dispatch}>
-            <label htmlFor="mailaddress">リクエストするメールアドレス</label>
-            <Input id="mailaddress" type="email" name="mailaddress" />
-            {state.error && <div>{state.error}</div>}
-            <Button type="submit">検索</Button>
-          </form>
-
-          {state.mailaddress && (
-            <Request mailaddress={state.mailaddress} name={state.name} />
-          )}
-        </CardContent>
+        {fromUserId && <RecievedRequest fromUserId={fromUserId} />}
+        <SendRequest />
       </Card>
     </Center>
   );
 }
 
-const Request = ({
-  mailaddress,
-  name,
-}: {
-  mailaddress: string;
-  name: string;
-}) => {
-  const [state, dispatch] = useFormState(sendRequest, {
-    mailaddress: '',
-    error: '',
-  });
-
-  return (
-    <form action={dispatch}>
-      <div>
-        <Input
-          type="email"
-          name="mailaddress"
-          defaultValue={mailaddress}
-          readOnly
-        />
-      </div>
-      <div className="text-lg">名前: {name}</div>
-      <Button type="submit">リクエストを送る</Button>
-      {state.error && <div>{state.error}</div>}
-      {!state.error && state.mailaddress && <div>リクエストしました</div>}
-    </form>
-  );
-};
+const getRequestQuery = gql`
+  query GetRequest {
+    getRequest {
+      fromUserId
+    }
+  }
+`;

--- a/frontend/lib/authClient.ts
+++ b/frontend/lib/authClient.ts
@@ -1,10 +1,16 @@
 import { AUTHORIZATION } from '@/app/api/auth/[...nextauth]/route';
-import { succeed } from 'effect/Effect';
+import { Effect, succeed } from 'effect/Effect';
 import { GraphQLClient } from 'graphql-request';
 import { cookies } from 'next/headers';
 import { failWithTag } from './Effect.lib';
 
-export const authClient = () => {
+export const authClient = (): Effect<
+  GraphQLClient,
+  {
+    readonly _tag: 'Unauthorized';
+  },
+  never
+> => {
   const client = new GraphQLClient(process.env.BACKEND_URL);
   const authorization = cookies().get(AUTHORIZATION)?.value;
 

--- a/frontend/types/gql/gql.ts
+++ b/frontend/types/gql/gql.ts
@@ -13,8 +13,10 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  */
 const documents = {
+    "\n  mutation CreateCouple($isAccepted: Boolean!) {\n    createCouple(isAccepted: $isAccepted) {\n      id\n    }\n  }\n": types.CreateCoupleDocument,
     "\n  query GetUserByMailaddress($mailaddress: String!) {\n    getUserByMailaddress(mailaddress: $mailaddress) {\n      mailaddress\n      name\n    }\n  }\n": types.GetUserByMailaddressDocument,
     "\n  mutation SendRequest($mailaddress: String!) {\n    sendRequest(mailaddress: $mailaddress)\n  }\n": types.SendRequestDocument,
+    "\n  query GetRequest {\n    getRequest {\n      fromUserId\n    }\n  }\n": types.GetRequestDocument,
     "\n  query Login($token: String!) {\n    login(token: $token)\n  }\n": types.LoginDocument,
     "\n  mutation CreateTempUser($mailaddress: String!) {\n    createTempUser(mailaddress: $mailaddress) {\n      token\n    }\n  }\n": types.CreateTempUserDocument,
     "\n  mutation CreateUser($name: String!, $createUserToken2: String!) {\n    createUser(name: $name, token: $createUserToken2) {\n      id\n    }\n  }\n": types.CreateUserDocument,
@@ -37,11 +39,19 @@ export function graphql(source: string): unknown;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
+export function graphql(source: "\n  mutation CreateCouple($isAccepted: Boolean!) {\n    createCouple(isAccepted: $isAccepted) {\n      id\n    }\n  }\n"): (typeof documents)["\n  mutation CreateCouple($isAccepted: Boolean!) {\n    createCouple(isAccepted: $isAccepted) {\n      id\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function graphql(source: "\n  query GetUserByMailaddress($mailaddress: String!) {\n    getUserByMailaddress(mailaddress: $mailaddress) {\n      mailaddress\n      name\n    }\n  }\n"): (typeof documents)["\n  query GetUserByMailaddress($mailaddress: String!) {\n    getUserByMailaddress(mailaddress: $mailaddress) {\n      mailaddress\n      name\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  mutation SendRequest($mailaddress: String!) {\n    sendRequest(mailaddress: $mailaddress)\n  }\n"): (typeof documents)["\n  mutation SendRequest($mailaddress: String!) {\n    sendRequest(mailaddress: $mailaddress)\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query GetRequest {\n    getRequest {\n      fromUserId\n    }\n  }\n"): (typeof documents)["\n  query GetRequest {\n    getRequest {\n      fromUserId\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/types/gql/graphql.ts
+++ b/frontend/types/gql/graphql.ts
@@ -54,6 +54,7 @@ export type MutationSendRequestArgs = {
 
 export type Query = {
   __typename?: 'Query';
+  getRequest: RequestPresenter;
   getUserByMailaddress: UserPresenter;
   login: Scalars['String']['output'];
 };
@@ -66,6 +67,14 @@ export type QueryGetUserByMailaddressArgs = {
 
 export type QueryLoginArgs = {
   token: Scalars['String']['input'];
+};
+
+export type RequestPresenter = {
+  __typename?: 'RequestPresenter';
+  fromUserId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  toUserId: Scalars['String']['output'];
+  typeId: Scalars['Float']['output'];
 };
 
 export type TempUserPresenter = {
@@ -82,6 +91,13 @@ export type UserPresenter = {
   name: Scalars['String']['output'];
 };
 
+export type CreateCoupleMutationVariables = Exact<{
+  isAccepted: Scalars['Boolean']['input'];
+}>;
+
+
+export type CreateCoupleMutation = { __typename?: 'Mutation', createCouple?: { __typename?: 'CouplePresenter', id: string } | null };
+
 export type GetUserByMailaddressQueryVariables = Exact<{
   mailaddress: Scalars['String']['input'];
 }>;
@@ -95,6 +111,11 @@ export type SendRequestMutationVariables = Exact<{
 
 
 export type SendRequestMutation = { __typename?: 'Mutation', sendRequest: boolean };
+
+export type GetRequestQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetRequestQuery = { __typename?: 'Query', getRequest: { __typename?: 'RequestPresenter', fromUserId: string } };
 
 export type LoginQueryVariables = Exact<{
   token: Scalars['String']['input'];
@@ -119,8 +140,10 @@ export type CreateUserMutationVariables = Exact<{
 export type CreateUserMutation = { __typename?: 'Mutation', createUser: { __typename?: 'UserPresenter', id: string } };
 
 
+export const CreateCoupleDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateCouple"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"isAccepted"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createCouple"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"isAccepted"},"value":{"kind":"Variable","name":{"kind":"Name","value":"isAccepted"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<CreateCoupleMutation, CreateCoupleMutationVariables>;
 export const GetUserByMailaddressDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetUserByMailaddress"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"mailaddress"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getUserByMailaddress"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"mailaddress"},"value":{"kind":"Variable","name":{"kind":"Name","value":"mailaddress"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"mailaddress"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<GetUserByMailaddressQuery, GetUserByMailaddressQueryVariables>;
 export const SendRequestDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SendRequest"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"mailaddress"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sendRequest"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"mailaddress"},"value":{"kind":"Variable","name":{"kind":"Name","value":"mailaddress"}}}]}]}}]} as unknown as DocumentNode<SendRequestMutation, SendRequestMutationVariables>;
+export const GetRequestDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetRequest"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getRequest"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"fromUserId"}}]}}]}}]} as unknown as DocumentNode<GetRequestQuery, GetRequestQueryVariables>;
 export const LoginDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Login"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"token"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"login"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"token"},"value":{"kind":"Variable","name":{"kind":"Name","value":"token"}}}]}]}}]} as unknown as DocumentNode<LoginQuery, LoginQueryVariables>;
 export const CreateTempUserDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateTempUser"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"mailaddress"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createTempUser"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"mailaddress"},"value":{"kind":"Variable","name":{"kind":"Name","value":"mailaddress"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"token"}}]}}]}}]} as unknown as DocumentNode<CreateTempUserMutation, CreateTempUserMutationVariables>;
 export const CreateUserDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateUser"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"createUserToken2"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createUser"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"token"},"value":{"kind":"Variable","name":{"kind":"Name","value":"createUserToken2"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<CreateUserMutation, CreateUserMutationVariables>;


### PR DESCRIPTION
- 受け取ったリクエストの表示と承認/拒否する機能をつけた
- 承認したらそのままカップル専用画面に遷移させたい
- 全体的にエラーハンドリングが適当