### PR TITLE
やること一覧画面にやること作成ダイアログを実装

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -25,7 +25,8 @@
     "**/node_modules/effect/dist/dts/Sink.d.ts",
     "**/node_modules/effect/dist/dts/Channel.d.ts",
     "**/node_modules/effect/dist/dts/Metric.d.ts",
-    "**/node_modules/effect/dist/dts/Tdeferred.d.ts"
+    "**/node_modules/effect/dist/dts/Tdeferred.d.ts",
+    "@radix/**"
   ],
 
   "eslint.experimental.useFlatConfig": true

--- a/frontend/app/(auth)/home/[listId]/ContentsRow.tsx
+++ b/frontend/app/(auth)/home/[listId]/ContentsRow.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import { setCompletedContents, setIncompleteContents } from './action';
+import { useRouter } from 'next/navigation';
+
+export const ContentsRow = ({
+  contentsId,
+  content,
+  isDone,
+}: {
+  contentsId: string;
+  content: string;
+  isDone: boolean;
+}) => {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-row items-center border p-4 gap-2">
+      <Checkbox
+        checked={isDone}
+        onClick={() => {
+          isDone
+            ? setIncompleteContents({ contentsId })
+            : setCompletedContents({ contentsId });
+          router.refresh();
+        }}
+      />
+      {content}
+    </div>
+  );
+};

--- a/frontend/app/(auth)/home/[listId]/CreateContentsDialog.tsx
+++ b/frontend/app/(auth)/home/[listId]/CreateContentsDialog.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { createContents } from './action';
+
+export const CreateContentsDialog = ({ listId }: { listId: string }) => {
+  const [visible, setVisible] = useState(false);
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<{ content: string }>();
+
+  const onSubmit = async ({
+    listId,
+    content,
+  }: {
+    listId: string;
+    content: string;
+  }) => {
+    await createContents({ listId, content });
+    setVisible(false);
+  };
+
+  return (
+    <Dialog open={visible} onOpenChange={setVisible}>
+      <DialogTrigger asChild>
+        <Button> やること作成</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogTitle>やること作成</DialogTitle>
+        <form
+          onSubmit={handleSubmit(({ content }: { content: string }) =>
+            onSubmit({ listId, content }),
+          )}
+        >
+          <Input
+            type="text"
+            placeholder="やること"
+            {...register('content', {
+              required: 'やることを入力してください',
+            })}
+          />
+          {errors.content && <p>{errors.content.message}</p>}
+          <Button type="submit">作成</Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/app/(auth)/home/[listId]/action/index.ts
+++ b/frontend/app/(auth)/home/[listId]/action/index.ts
@@ -32,7 +32,7 @@ export const createContents = async ({
           createContentsMutation,
           { listId, content },
         ),
-      catch: () => tag('fail create list'),
+      catch: () => tag('fail create contents'),
     });
 
     return {
@@ -46,7 +46,7 @@ export const createContents = async ({
           succeed({
             error: 'やることを入力してください',
           }),
-        'fail create list': () =>
+        'fail create contents': () =>
           succeed({
             error: 'やることの作成に失敗しました',
           }),

--- a/frontend/app/(auth)/home/_list/index.tsx
+++ b/frontend/app/(auth)/home/_list/index.tsx
@@ -22,7 +22,7 @@ export const HomeList = async () => {
         <CardContent>
           <CreateListDialog />
           {lists.getLists.map((list) => (
-            <ListColumn listId={list.id} listName={list.name} />
+            <ListRow listId={list.id} listName={list.name} />
           ))}
         </CardContent>
       </Card>
@@ -30,14 +30,14 @@ export const HomeList = async () => {
   );
 };
 
-const ListColumn = ({
+const ListRow = ({
   listId,
   listName,
 }: {
   listId: string;
   listName: string;
 }) => (
-  <div className="flex flex-col justify-center border p-4">
+  <div className="flex flex-row items-center border p-4">
     <Link href={`/home/${listId}`}>{listName}</Link>
   </div>
 );

--- a/frontend/components/ui/checkbox.tsx
+++ b/frontend/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-checkbox": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-slot": "^1.0.2",
         "class-variance-authority": "^0.7.0",
@@ -2796,6 +2797,35 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
       "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.1.1.tgz",
+      "integrity": "sha512-0i/EKJ222Afa1FE0C6pNJxDq1itzcl3HChE9DwskA4th4KRse8ojx8a1nVcOjwJdbpDLcz7uol77yYnQNMHdKw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
@@ -3077,6 +3107,37 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
       "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "codegen": "graphql-codegen"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",

--- a/frontend/types/gql/gql.ts
+++ b/frontend/types/gql/gql.ts
@@ -13,9 +13,12 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  */
 const documents = {
+    "\n  mutation CreateContents($listId: String!, $content: String!) {\n    createContents(listId: $listId, content: $content) {\n      id\n    }\n  }\n": types.CreateContentsDocument,
+    "\n  mutation SetCompletedContents($setCompletedContentsId: String!) {\n    setCompletedContents(id: $setCompletedContentsId) {\n      id\n    }\n  }\n": types.SetCompletedContentsDocument,
+    "\n  mutation SetIncompleteContents($setIncompleteContentsId: String!) {\n    setIncompleteContents(id: $setIncompleteContentsId) {\n      id\n    }\n  }\n": types.SetIncompleteContentsDocument,
+    "\n  query GetLists {\n    getLists {\n      id\n      name\n    }\n  }\n": types.GetListsDocument,
     "\n  query getContentsByListId($listId: String!) {\n    getContentsByListId(listId: $listId) {\n      id\n      content\n      isDone\n    }\n  }\n": types.GetContentsByListIdDocument,
     "\n  mutation CreateList($name: String!) {\n    createList(name: $name) {\n      id\n    }\n  }\n": types.CreateListDocument,
-    "\n  query GetLists {\n    getLists {\n      id\n      name\n    }\n  }\n": types.GetListsDocument,
     "\n  query GetUserByMailaddress($mailaddress: String!) {\n    getUserByMailaddress(mailaddress: $mailaddress) {\n      mailaddress\n      name\n    }\n  }\n": types.GetUserByMailaddressDocument,
     "\n  mutation SendRequest($mailaddress: String!) {\n    sendRequest(mailaddress: $mailaddress)\n  }\n": types.SendRequestDocument,
     "\n  mutation CreateCouple($isAccepted: Boolean!) {\n    createCouple(isAccepted: $isAccepted) {\n      id\n    }\n  }\n": types.CreateCoupleDocument,
@@ -43,15 +46,27 @@ export function graphql(source: string): unknown;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
+export function graphql(source: "\n  mutation CreateContents($listId: String!, $content: String!) {\n    createContents(listId: $listId, content: $content) {\n      id\n    }\n  }\n"): (typeof documents)["\n  mutation CreateContents($listId: String!, $content: String!) {\n    createContents(listId: $listId, content: $content) {\n      id\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation SetCompletedContents($setCompletedContentsId: String!) {\n    setCompletedContents(id: $setCompletedContentsId) {\n      id\n    }\n  }\n"): (typeof documents)["\n  mutation SetCompletedContents($setCompletedContentsId: String!) {\n    setCompletedContents(id: $setCompletedContentsId) {\n      id\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation SetIncompleteContents($setIncompleteContentsId: String!) {\n    setIncompleteContents(id: $setIncompleteContentsId) {\n      id\n    }\n  }\n"): (typeof documents)["\n  mutation SetIncompleteContents($setIncompleteContentsId: String!) {\n    setIncompleteContents(id: $setIncompleteContentsId) {\n      id\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query GetLists {\n    getLists {\n      id\n      name\n    }\n  }\n"): (typeof documents)["\n  query GetLists {\n    getLists {\n      id\n      name\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function graphql(source: "\n  query getContentsByListId($listId: String!) {\n    getContentsByListId(listId: $listId) {\n      id\n      content\n      isDone\n    }\n  }\n"): (typeof documents)["\n  query getContentsByListId($listId: String!) {\n    getContentsByListId(listId: $listId) {\n      id\n      content\n      isDone\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  mutation CreateList($name: String!) {\n    createList(name: $name) {\n      id\n    }\n  }\n"): (typeof documents)["\n  mutation CreateList($name: String!) {\n    createList(name: $name) {\n      id\n    }\n  }\n"];
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(source: "\n  query GetLists {\n    getLists {\n      id\n      name\n    }\n  }\n"): (typeof documents)["\n  query GetLists {\n    getLists {\n      id\n      name\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/types/gql/graphql.ts
+++ b/frontend/types/gql/graphql.ts
@@ -46,6 +46,8 @@ export type Mutation = {
   createTempUser: TempUserPresenter;
   createUser: UserPresenter;
   sendRequest: Scalars['Boolean']['output'];
+  setCompletedContents: ContentsPresenter;
+  setIncompleteContents: ContentsPresenter;
   updateContents: ContentsPresenter;
   updateList: ListPresenter;
 };
@@ -80,6 +82,16 @@ export type MutationCreateUserArgs = {
 
 export type MutationSendRequestArgs = {
   mailaddress: Scalars['String']['input'];
+};
+
+
+export type MutationSetCompletedContentsArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type MutationSetIncompleteContentsArgs = {
+  id: Scalars['String']['input'];
 };
 
 
@@ -141,6 +153,33 @@ export type UserPresenter = {
   name: Scalars['String']['output'];
 };
 
+export type CreateContentsMutationVariables = Exact<{
+  listId: Scalars['String']['input'];
+  content: Scalars['String']['input'];
+}>;
+
+
+export type CreateContentsMutation = { __typename?: 'Mutation', createContents: { __typename?: 'ContentsPresenter', id: string } };
+
+export type SetCompletedContentsMutationVariables = Exact<{
+  setCompletedContentsId: Scalars['String']['input'];
+}>;
+
+
+export type SetCompletedContentsMutation = { __typename?: 'Mutation', setCompletedContents: { __typename?: 'ContentsPresenter', id: string } };
+
+export type SetIncompleteContentsMutationVariables = Exact<{
+  setIncompleteContentsId: Scalars['String']['input'];
+}>;
+
+
+export type SetIncompleteContentsMutation = { __typename?: 'Mutation', setIncompleteContents: { __typename?: 'ContentsPresenter', id: string } };
+
+export type GetListsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetListsQuery = { __typename?: 'Query', getLists: Array<{ __typename?: 'ListPresenter', id: string, name: string }> };
+
 export type GetContentsByListIdQueryVariables = Exact<{
   listId: Scalars['String']['input'];
 }>;
@@ -154,11 +193,6 @@ export type CreateListMutationVariables = Exact<{
 
 
 export type CreateListMutation = { __typename?: 'Mutation', createList: { __typename?: 'ListPresenter', id: string } };
-
-export type GetListsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetListsQuery = { __typename?: 'Query', getLists: Array<{ __typename?: 'ListPresenter', id: string, name: string }> };
 
 export type GetUserByMailaddressQueryVariables = Exact<{
   mailaddress: Scalars['String']['input'];
@@ -214,9 +248,12 @@ export type CreateUserMutationVariables = Exact<{
 export type CreateUserMutation = { __typename?: 'Mutation', createUser: { __typename?: 'UserPresenter', id: string } };
 
 
+export const CreateContentsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateContents"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"listId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"content"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createContents"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"listId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"listId"}}},{"kind":"Argument","name":{"kind":"Name","value":"content"},"value":{"kind":"Variable","name":{"kind":"Name","value":"content"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<CreateContentsMutation, CreateContentsMutationVariables>;
+export const SetCompletedContentsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetCompletedContents"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"setCompletedContentsId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setCompletedContents"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"setCompletedContentsId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<SetCompletedContentsMutation, SetCompletedContentsMutationVariables>;
+export const SetIncompleteContentsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetIncompleteContents"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"setIncompleteContentsId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"setIncompleteContents"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"setIncompleteContentsId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<SetIncompleteContentsMutation, SetIncompleteContentsMutationVariables>;
+export const GetListsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetLists"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getLists"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<GetListsQuery, GetListsQueryVariables>;
 export const GetContentsByListIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"getContentsByListId"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"listId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getContentsByListId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"listId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"listId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"content"}},{"kind":"Field","name":{"kind":"Name","value":"isDone"}}]}}]}}]} as unknown as DocumentNode<GetContentsByListIdQuery, GetContentsByListIdQueryVariables>;
 export const CreateListDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateList"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createList"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<CreateListMutation, CreateListMutationVariables>;
-export const GetListsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetLists"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getLists"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<GetListsQuery, GetListsQueryVariables>;
 export const GetUserByMailaddressDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetUserByMailaddress"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"mailaddress"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getUserByMailaddress"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"mailaddress"},"value":{"kind":"Variable","name":{"kind":"Name","value":"mailaddress"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"mailaddress"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<GetUserByMailaddressQuery, GetUserByMailaddressQueryVariables>;
 export const SendRequestDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SendRequest"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"mailaddress"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"sendRequest"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"mailaddress"},"value":{"kind":"Variable","name":{"kind":"Name","value":"mailaddress"}}}]}]}}]} as unknown as DocumentNode<SendRequestMutation, SendRequestMutationVariables>;
 export const CreateCoupleDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateCouple"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"isAccepted"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createCouple"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"isAccepted"},"value":{"kind":"Variable","name":{"kind":"Name","value":"isAccepted"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<CreateCoupleMutation, CreateCoupleMutationVariables>;


### PR DESCRIPTION
- やること作成ダイアログをつくった
- チェックボックスをクリックしてから反映されるのが遅い
  - 楽観的更新でやりたい
- ソートが怪しい
  - updated_atとかでソートしたほうがいいかも

![image](https://github.com/exchange-wata/SweetheartSuite/assets/40950720/5b36a378-bc07-475c-841c-bd653b03a5a2)
