### PR TITLE
migration更新&リストアーカイブを実装

### DIFF
--- a/backend/prisma/migrations/20240709001709_add_column_to_list/migration.sql
+++ b/backend/prisma/migrations/20240709001709_add_column_to_list/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "list"."List" ADD COLUMN     "isArchived" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -78,6 +78,7 @@ model List {
   id        String @id @default(uuid())
   coupleId  String
   name      String
+  isArchived Boolean @default(false)
   contents  Contents[]
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now())

--- a/backend/src/context/List/adapters/presenter/list.presenter.ts
+++ b/backend/src/context/List/adapters/presenter/list.presenter.ts
@@ -4,6 +4,7 @@ type ListType = {
   id: string;
   name: string;
   coupleId: string;
+  isArchived: boolean
 };
 
 @ObjectType()
@@ -17,10 +18,14 @@ export class ListPresenter {
   @Field()
   coupleId: string;
 
+  @Field()
+  isArchived: boolean
+
   constructor(input: ListType) {
     this.id = input.id;
     this.name = input.name;
     this.coupleId = input.coupleId;
+    this.isArchived = input.isArchived;
   }
 
   static create(input: ListType) {

--- a/backend/src/context/List/adapters/resolver/list.resolver.ts
+++ b/backend/src/context/List/adapters/resolver/list.resolver.ts
@@ -2,10 +2,11 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { JwtAuth } from 'src/context/Auth/decorator/jwtAuth.decorator';
 import { GetCoupleUsecase } from 'src/context/User/usecase/getCouple.usecase';
 import { User } from '../../../User/decorator/user.decorator';
+import { ArchiveListUsecase } from '../../usecase/archiveList.usecase';
 import { CreateListUsecase } from '../../usecase/createList.usecase';
+import { GetListsUsecase } from '../../usecase/getLists.usecase';
 import { UpdateListUsecase } from '../../usecase/updateList.usecase';
 import { ListPresenter } from '../presenter/list.presenter';
-import { GetListsUsecase } from '../../usecase/getLists.usecase';
 
 @Resolver()
 @JwtAuth()
@@ -15,6 +16,7 @@ export class ListResolver {
     private readonly createListUsecase: CreateListUsecase,
     private readonly getCoupleUsecase: GetCoupleUsecase,
     private readonly updateListUsecase: UpdateListUsecase,
+    private readonly archiveListUsecase: ArchiveListUsecase,
   ) {}
 
   @Query(() => [ListPresenter])
@@ -34,6 +36,12 @@ export class ListResolver {
   @Mutation(() => ListPresenter)
   async updateList(@Args('listId') listId: string, @Args('name') name: string) {
     const list = await this.updateListUsecase.execute(listId, name);
+    return ListPresenter.create(list);
+  }
+
+  @Mutation(() => ListPresenter)
+  async archiveList(@Args('listId') listId: string) {
+    const list = await this.archiveListUsecase.execute(listId)
     return ListPresenter.create(list);
   }
 }

--- a/backend/src/context/List/domain/model/list.model.ts
+++ b/backend/src/context/List/domain/model/list.model.ts
@@ -4,17 +4,20 @@ type ListType = {
   id?: string;
   name: string;
   coupleId: string;
+  isArchived?: boolean
 };
 
 export class ListModel {
   id: string;
   name: string;
   coupleId: string;
+  isArchived: boolean
 
-  private constructor(input: { id: string; name: string; coupleId: string }) {
+  private constructor(input: { id: string; name: string; coupleId: string, isArchived: boolean }) {
     this.id = input.id;
     this.name = input.name;
     this.coupleId = input.coupleId;
+    this.isArchived = input.isArchived;
   }
 
   public static create = (input: ListType) =>
@@ -22,10 +25,16 @@ export class ListModel {
       id: input.id ?? crypto.randomUUID(),
       name: input.name,
       coupleId: input.coupleId,
+      isArchived: input.isArchived,
     });
 
   public updateName = (name: string) => {
     this.name = name;
+    return this;
+  };
+
+  public setCompleted = () => {
+    this.isArchived = true;
     return this;
   };
 }

--- a/backend/src/context/List/infra/list.repository.ts
+++ b/backend/src/context/List/infra/list.repository.ts
@@ -63,6 +63,7 @@ export class ListRepository implements ListRepositoryInterface {
             },
             data: {
               name: listModel.name,
+              isArchived: listModel.isArchived,
               updatedAt: new Date(),
             },
           }),

--- a/backend/src/context/List/list.module.ts
+++ b/backend/src/context/List/list.module.ts
@@ -9,6 +9,7 @@ import { ListResolver } from './adapters/resolver/list.resolver';
 import { CONTENTS_REPOSITORY, LIST_REPOSITORY } from './const/list.token';
 import { ContentsRepository } from './infra/contents.repository';
 import { ListRepository } from './infra/list.repository';
+import { ArchiveListUsecase } from './usecase/archiveList.usecase';
 import { CreateContentsUsecase } from './usecase/createContents.usecase';
 import { CreateListUsecase } from './usecase/createList.usecase';
 import { GetContentsByListIdUsecase } from './usecase/getContentsByListId.usecase';
@@ -32,6 +33,7 @@ import { UpdateListUsecase } from './usecase/updateList.usecase';
     UpdateContentsUsecase,
     SetCompletedContentsUsecase,
     SetIncompleteContentsUsecase,
+    ArchiveListUsecase,
     PrismaService,
     { provide: LIST_REPOSITORY, useClass: ListRepository },
     { provide: COUPLE_REPOSITORY, useClass: CoupleRepository },

--- a/backend/src/context/List/test/domain/model/list.model.test.ts
+++ b/backend/src/context/List/test/domain/model/list.model.test.ts
@@ -23,5 +23,19 @@ describe('couple modelのテスト', () => {
       const updatedListModel = currentListModel.updateName(updatedName);
       expect(updatedListModel.name).toEqual(updatedName);
     });
+
+    it('isArchivedの更新', () => {
+      const input = {
+        id: '7ff7e40a-3040-4119-836d-321c40d1b732',
+        name: 'テスト',
+        coupleId: 'c2f068b2-57bd-4074-9228-2a13e18141ee',
+        isArchived: false
+      };
+      const updatedArchiveFlag = true;
+
+      const currentListModel = ListModel.create(input);
+      const updatedListModel = currentListModel.setCompleted();
+      expect(updatedListModel.isArchived).toEqual(updatedArchiveFlag);
+    });
   });
 });

--- a/backend/src/context/List/test/usecase/archiveList.usecase.test.ts
+++ b/backend/src/context/List/test/usecase/archiveList.usecase.test.ts
@@ -23,19 +23,17 @@ const updatedListModel = ListModel.create({
 });
 
 describe('ArchiveListUsecase', () => {
-    it('紐づくコンテンツに一つでも未完了が存在するとき、リストは未完了のままになる', async () => {
+    it('紐づくコンテンツに一つでも未完了が存在するとき、エラーになる', async () => {
     const contentsRepository: Pick<ContentsRepositoryInterface, 'findByListId'> = {
       findByListId: jest.fn(() => Effect.succeed(incompleteContents)),
     };
     const listRepository: Pick<ListRepositoryInterface, 'findByListId' | 'update'> = {
       findByListId: jest.fn(() => Effect.succeed(currentListModel)),
-      update: jest.fn(() => Effect.succeed(currentListModel)),
+      update: jest.fn(() => Effect.succeed(updatedListModel)),
     };
     const usecase = new ArchiveListUsecase(listRepository as ListRepositoryInterface, contentsRepository as ContentsRepositoryInterface);
 
-    const result = await usecase.execute(listId);
-    expect(listRepository.update).not.toHaveBeenCalled();
-    expect(result.isArchived).toBe(false);
+    await expect(usecase.execute(listId)).rejects.toThrow()
   });
 
   it('紐づくコンテンツが全て完了している時、リストが完了になる', async () => {
@@ -49,7 +47,6 @@ describe('ArchiveListUsecase', () => {
     const usecase = new ArchiveListUsecase(listRepository as ListRepositoryInterface, contentsRepository as ContentsRepositoryInterface);
 
     const result = await usecase.execute(listId);
-    expect(listRepository.update).toHaveBeenCalledTimes(1);
     expect(result.isArchived).toBe(true);
   });
 });

--- a/backend/src/context/List/test/usecase/archiveList.usecase.test.ts
+++ b/backend/src/context/List/test/usecase/archiveList.usecase.test.ts
@@ -1,0 +1,55 @@
+import { Effect } from 'effect';
+import { ContentsRepositoryInterface } from '../../domain/interface/contents.repository.interface';
+import { ListRepositoryInterface } from '../../domain/interface/list.repository.interface';
+import { ContentsModel } from '../../domain/model/contents.model';
+import { ListModel } from '../../domain/model/list.model';
+import { ArchiveListUsecase } from '../../usecase/archiveList.usecase';
+
+const listId = 'list-id';
+const coupleId = 'couple-id'
+const contents = [
+  ContentsModel.create({ id: 'content1', listId, content: 'Test Content 1', isDone: true }),
+  ContentsModel.create({ id: 'content2', listId, content: 'Test Content 2', isDone: true }),
+];
+const incompleteContents = [
+  ContentsModel.create({ id: 'content1', listId, content: 'Test Content 1', isDone: true }),
+  ContentsModel.create({ id: 'content2', listId, content: 'Test Content 2', isDone: false }),
+];
+const currentListModel = ListModel.create({
+  id: listId, name: 'Test List', isArchived: false, coupleId
+});
+const updatedListModel = ListModel.create({
+  id: listId, name: 'Test List Updated', isArchived: true, coupleId
+});
+
+describe('ArchiveListUsecase', () => {
+    it('紐づくコンテンツに一つでも未完了が存在するとき、リストは未完了のままになる', async () => {
+    const contentsRepository: Pick<ContentsRepositoryInterface, 'findByListId'> = {
+      findByListId: jest.fn(() => Effect.succeed(incompleteContents)),
+    };
+    const listRepository: Pick<ListRepositoryInterface, 'findByListId' | 'update'> = {
+      findByListId: jest.fn(() => Effect.succeed(currentListModel)),
+      update: jest.fn(() => Effect.succeed(currentListModel)),
+    };
+    const usecase = new ArchiveListUsecase(listRepository as ListRepositoryInterface, contentsRepository as ContentsRepositoryInterface);
+
+    const result = await usecase.execute(listId);
+    expect(listRepository.update).not.toHaveBeenCalled();
+    expect(result.isArchived).toBe(false);
+  });
+
+  it('紐づくコンテンツが全て完了している時、リストが完了になる', async () => {
+    const contentsRepository: Pick<ContentsRepositoryInterface, 'findByListId'> = {
+      findByListId: jest.fn(() => Effect.succeed(contents)),
+    };
+    const listRepository: Pick<ListRepositoryInterface, 'findByListId' | 'update'> = {
+      findByListId: jest.fn(() => Effect.succeed(currentListModel)),
+      update: jest.fn(() => Effect.succeed(updatedListModel)),
+    };
+    const usecase = new ArchiveListUsecase(listRepository as ListRepositoryInterface, contentsRepository as ContentsRepositoryInterface);
+
+    const result = await usecase.execute(listId);
+    expect(listRepository.update).toHaveBeenCalledTimes(1);
+    expect(result.isArchived).toBe(true);
+  });
+});

--- a/backend/src/context/List/usecase/archiveList.usecase.ts
+++ b/backend/src/context/List/usecase/archiveList.usecase.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { gen, runPromise } from 'effect/Effect';
+import { CONTENTS_REPOSITORY, LIST_REPOSITORY } from '../const/list.token';
+import { ContentsRepositoryInterface } from '../domain/interface/contents.repository.interface';
+import { ListRepositoryInterface } from '../domain/interface/list.repository.interface';
+import { ContentsModel } from '../domain/model/contents.model';
+
+@Injectable()
+export class ArchiveListUsecase {
+  constructor(
+    @Inject(LIST_REPOSITORY)
+    private readonly listRepository: ListRepositoryInterface,
+    @Inject(CONTENTS_REPOSITORY)
+    private readonly contentsRepository: ContentsRepositoryInterface,
+  ) {}
+
+  execute = (listId: string) => {
+    const self = this;
+    return gen(function* () {
+      const contents = yield* self.contentsRepository.findByListId(listId)
+      const currentListModel = yield* self.listRepository.findByListId(listId)
+
+      if (self.areAllContentsDone(contents)) {
+        const updatedListModel = currentListModel.setCompleted()
+        const list = yield* self.listRepository.update(updatedListModel)
+        return list
+      } else {
+        return currentListModel
+      }
+    }).pipe(runPromise);
+  };
+
+  private areAllContentsDone = (contents: ContentsModel[]): boolean => 
+    contents.every(content => content.isDone)
+}


### PR DESCRIPTION
## 実装内容
- listに紐づくcontentsが全て完了済みだったらリストのアーカイブを行う
  - テスト実装
  - カラム追加

## 実行結果
 (↓画像はアーカイブ時のもの)
![スクリーンショット 2024-07-09 11 22 48](https://github.com/exchange-wata/SweetheartSuite/assets/36654133/d6aac385-ff4a-4306-94bf-7342d9064ea3)
