### PR TITLE
listの認可を実装

### DIFF
--- a/backend/src/context/List/adapters/resolver/list.resolver.ts
+++ b/backend/src/context/List/adapters/resolver/list.resolver.ts
@@ -2,6 +2,7 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { JwtAuth } from 'src/context/Auth/decorator/jwtAuth.decorator';
 import { GetCoupleUsecase } from 'src/context/User/usecase/getCouple.usecase';
 import { User } from '../../../User/decorator/user.decorator';
+import { ListAuth } from '../../decorator/list.decorator';
 import { ArchiveListUsecase } from '../../usecase/archiveList.usecase';
 import { CreateListUsecase } from '../../usecase/createList.usecase';
 import { GetListsUsecase } from '../../usecase/getLists.usecase';
@@ -21,26 +22,24 @@ export class ListResolver {
 
   @Query(() => [ListPresenter])
   async getLists(@User() user: any) {
-    const couple = await this.getCoupleUsecase.execute(user.userId);
-    if (couple === undefined) throw new Error('couple could not find');
-    const lists = await this.getListsUsecase.execute(couple.id);
+    const lists = await this.getListsUsecase.execute(user.coupleId);
     return lists.map(ListPresenter.create);
   }
 
   @Mutation(() => ListPresenter)
   async createList(@User() user: any, @Args('name') name: string) {
-    const couple = await this.getCoupleUsecase.execute(user.userId);
-    if (couple === undefined) throw new Error('couple could not find');
-    const list = await this.createListUsecase.execute(couple.id, name);
+    const list = await this.createListUsecase.execute(user.coupleId, name);
     return ListPresenter.create(list);
   }
 
+  @ListAuth()
   @Mutation(() => ListPresenter)
   async updateList(@Args('listId') listId: string, @Args('name') name: string) {
     const list = await this.updateListUsecase.execute(listId, name);
     return ListPresenter.create(list);
   }
 
+  @ListAuth()
   @Mutation(() => ListPresenter)
   async archiveList(@Args('listId') listId: string) {
     const list = await this.archiveListUsecase.execute(listId);

--- a/backend/src/context/List/decorator/list.decorator.ts
+++ b/backend/src/context/List/decorator/list.decorator.ts
@@ -1,0 +1,6 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { ListAuthGuard } from '../guard/list.guard';
+
+export function ListAuth() {
+  return applyDecorators(UseGuards(ListAuthGuard));
+}

--- a/backend/src/context/List/guard/list.guard.ts
+++ b/backend/src/context/List/guard/list.guard.ts
@@ -1,0 +1,18 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { GetListByIdUsecase } from '../usecase/getListById.usecase';
+
+@Injectable()
+export class ListAuthGuard implements CanActivate {
+  constructor(private readonly getListByIdUsecase: GetListByIdUsecase) {}
+
+  canActivate = async (context: ExecutionContext) => {
+    const ctx = GqlExecutionContext.create(context);
+    const request = ctx.getContext().req;
+    const coupleId = request.user.coupleId;
+    const listId = request.body.variables.listId;
+    const list = await this.getListByIdUsecase.execute(listId);
+
+    return list.coupleId === coupleId;
+  };
+}

--- a/backend/src/context/List/list.module.ts
+++ b/backend/src/context/List/list.module.ts
@@ -14,6 +14,7 @@ import { CreateContentsUsecase } from './usecase/createContents.usecase';
 import { CreateListUsecase } from './usecase/createList.usecase';
 import { DeleteContentsUsecase } from './usecase/deleteContents.usecase';
 import { GetContentsByListIdUsecase } from './usecase/getContentsByListId.usecase';
+import { GetListByIdUsecase } from './usecase/getListById.usecase';
 import { GetListsUsecase } from './usecase/getLists.usecase';
 import { SetCompletedContentsUsecase } from './usecase/setCompletedContents.usecase';
 import { SetIncompleteContentsUsecase } from './usecase/setIncompleteContents.usecase';
@@ -36,6 +37,7 @@ import { UpdateListUsecase } from './usecase/updateList.usecase';
     SetIncompleteContentsUsecase,
     ArchiveListUsecase,
     DeleteContentsUsecase,
+    GetListByIdUsecase,
     PrismaService,
     { provide: LIST_REPOSITORY, useClass: ListRepository },
     { provide: COUPLE_REPOSITORY, useClass: CoupleRepository },

--- a/backend/src/context/List/test/guard/list.guard.test.ts
+++ b/backend/src/context/List/test/guard/list.guard.test.ts
@@ -1,0 +1,67 @@
+import { ExecutionContext } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { ListModel } from '../../domain/model/list.model';
+import { ListAuthGuard } from '../../guard/list.guard';
+import { GetListByIdUsecase } from '../../usecase/getListById.usecase';
+
+let guard: ListAuthGuard;
+let getListByIdUsecase: GetListByIdUsecase;
+
+const mockExecutionContext: Partial<ExecutionContext> = {
+  switchToHttp: jest.fn(),
+};
+
+const mocks = (coupleId: string) => {
+  const mockGqlExecutionContext = {
+    create: jest.fn().mockReturnValue({
+      getContext: jest.fn().mockReturnValue({
+        req: {
+          user: { coupleId },
+          body: { variables: { listId: 'list-1' } },
+        },
+      }),
+    }),
+  };
+
+  const mockList = ListModel.create({
+    id: 'list-1',
+    coupleId: '123',
+    name: 'list',
+  });
+
+  jest.spyOn(getListByIdUsecase, 'execute').mockResolvedValue(mockList);
+  jest
+    .spyOn(GqlExecutionContext, 'create')
+    .mockReturnValue(mockGqlExecutionContext.create());
+};
+
+beforeEach(() => {
+  getListByIdUsecase = {
+    execute: jest.fn(),
+  } as any;
+  guard = new ListAuthGuard(getListByIdUsecase);
+});
+
+describe('ListAuthGuard', () => {
+  it('coupleIdと操作対象が適切な時、trueが返る', async () => {
+    mocks('123');
+
+    const result = await guard.canActivate(
+      mockExecutionContext as ExecutionContext,
+    );
+
+    expect(result).toBe(true);
+    expect(getListByIdUsecase.execute).toHaveBeenCalledWith('list-1');
+  });
+
+  it('coupleIdと操作対象が不適切な時、falseが返る', async () => {
+    mocks('456');
+
+    const result = await guard.canActivate(
+      mockExecutionContext as ExecutionContext,
+    );
+
+    expect(result).toBe(false);
+    expect(getListByIdUsecase.execute).toHaveBeenCalledWith('list-1');
+  });
+});

--- a/backend/src/context/List/test/usecase/getListById.usecase.test.ts
+++ b/backend/src/context/List/test/usecase/getListById.usecase.test.ts
@@ -1,0 +1,24 @@
+import { Effect } from 'effect';
+import { ListModel } from '../../domain/model/list.model';
+import { ListRepository } from '../../infra/list.repository';
+import { GetListByIdUsecase } from '../../usecase/getListById.usecase';
+
+const list = ListModel.create({
+  id: 'list-id1',
+  name: 'テスト1',
+  coupleId: 'couple-id1',
+});
+
+const listRepository: Pick<ListRepository, 'findByListId'> = {
+  findByListId: jest.fn(() => Effect.succeed(list)),
+};
+const getListByIdUsecase = new GetListByIdUsecase(
+  listRepository as ListRepository,
+);
+
+describe('GetListByIdUsecase', () => {
+  it('正常系', async () => {
+    const result = await getListByIdUsecase.execute('list-id1');
+    expect(result).toEqual(list);
+  });
+});

--- a/backend/src/context/List/usecase/getListById.usecase.ts
+++ b/backend/src/context/List/usecase/getListById.usecase.ts
@@ -1,0 +1,15 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { runPromise } from 'effect/Effect';
+import { LIST_REPOSITORY } from '../const/list.token';
+import { ListRepositoryInterface } from '../domain/interface/list.repository.interface';
+
+@Injectable()
+export class GetListByIdUsecase {
+  constructor(
+    @Inject(LIST_REPOSITORY)
+    private readonly listRepository: ListRepositoryInterface,
+  ) {}
+
+  execute = (id: string) =>
+    this.listRepository.findByListId(id).pipe(runPromise);
+}


### PR DESCRIPTION
## 実装内容
- requestに存在するユーザー情報(couple_id)と、queryのlist_idから取れるcouple_idを比較する
- →guard, decorator, test実装