### PR TITLE
雑にパンくずリストを実装

### DIFF
--- a/frontend/app/(auth)/home/[listId]/page.tsx
+++ b/frontend/app/(auth)/home/[listId]/page.tsx
@@ -11,6 +11,7 @@ import { gen, runPromise, tryPromise } from 'effect/Effect';
 import { gql } from 'graphql-request';
 import { CreateContentsDialog } from './CreateContentsDialog';
 import { ContentsRow } from './ContentsRow';
+import { Breadcrumb } from '@/app/Breadcrumb';
 
 export default async function List({ params }: { params: { listId: string } }) {
   const client = authClient();
@@ -32,21 +33,26 @@ export default async function List({ params }: { params: { listId: string } }) {
 
   return (
     <Center className="m-10">
-      <Card size="lg" className="flex-col items-center justify-center p-5">
-        <CardHeader className="items-center">{list.name}</CardHeader>
-        <CardContent className="flex flex-col gap-2">
-          <CreateContentsDialog listId={params.listId} />
-          <div className="flex flex-col gap-1">
-            {contents.getContentsByListId.map((content) => (
-              <ContentsRow
-                contentsId={content.id}
-                content={content.content}
-                isDone={content.isDone}
-              />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      <div>
+        <Breadcrumb
+          paths={[{ name: 'ホーム', href: '/home' }, { name: 'リスト' }]}
+        />
+        <Card size="lg" className="flex-col items-center justify-center p-5">
+          <CardHeader className="items-center">{list.name}</CardHeader>
+          <CardContent className="flex flex-col gap-2">
+            <CreateContentsDialog listId={params.listId} />
+            <div className="flex flex-col gap-1">
+              {contents.getContentsByListId.map((content) => (
+                <ContentsRow
+                  contentsId={content.id}
+                  content={content.content}
+                  isDone={content.isDone}
+                />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
     </Center>
   );
 }

--- a/frontend/app/Breadcrumb.tsx
+++ b/frontend/app/Breadcrumb.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+
+type PrevPath = {
+  name: string;
+  href: string;
+};
+
+type CurrentPath = {
+  name: string;
+};
+
+type Props = {
+  paths: [...PrevPath[], CurrentPath];
+};
+
+export const Breadcrumb = ({ paths }: Props) => {
+  return (
+    <nav aria-label="Breadcrumb" className="bg-gray-100 p-3 text-sm">
+      <ol className="list-none flex">
+        {paths.map((path, index) =>
+          index < paths.length - 1 ? (
+            <>
+              <li>
+                <Link
+                  href={(path as PrevPath).href}
+                  className="text-blue-500 hover:text-blue-600"
+                >
+                  {path.name}
+                </Link>
+              </li>
+              <li className="mx-2">{'>'}</li>
+            </>
+          ) : (
+            <li>
+              <span>{path.name}</span>
+            </li>
+          ),
+        )}
+      </ol>
+    </nav>
+  );
+};


### PR DESCRIPTION
- パンくずリストを実装
- 現在のページから動的に作るのはかなり面倒そうだったので、配列で渡すような感じにした

![image](https://github.com/user-attachments/assets/72d49bd7-645c-4ae8-b212-bba33ca1a8cb)
